### PR TITLE
Load only DLLs as plugins, and a few other changes.

### DIFF
--- a/MonoPatcher.CPP/include/Core.h
+++ b/MonoPatcher.CPP/include/Core.h
@@ -6,8 +6,16 @@ class Core {
 public:
 	bool Initialize();
 	void LoadPlugins();
+	void InitializePlugins();
 	static bool Create();
 	static Core* GetInstance();
+
+	struct PluginInitContext {
+		// We don't supply plugins with any data during initialization--yet,
+		// but we do give them a version number for the structure,
+		// so that we can add additional data without breaking ABI-compatibility.
+		uint8_t structureVersion = 0;
+	};
 
 	std::vector<HMODULE> loadedPlugins;
 private:

--- a/MonoPatcher.CPP/include/Core.h
+++ b/MonoPatcher.CPP/include/Core.h
@@ -1,10 +1,15 @@
 #pragma once
+#include "pch.h"
+#include <vector>
 
 class Core {
 public:
 	bool Initialize();
+	void LoadPlugins();
 	static bool Create();
 	static Core* GetInstance();
+
+	std::vector<HMODULE> loadedPlugins;
 private:
 	static Core* _instance;
 };

--- a/MonoPatcher.CPP/src/Core.cpp
+++ b/MonoPatcher.CPP/src/Core.cpp
@@ -1,6 +1,6 @@
-#include "pch.h"
 #include "Core.h"
 #include "iostream"
+#include <filesystem>
 #include "MinHook.h"
 #include "Sims3/ScriptHost.h"
 #include "GameAddresses.h"
@@ -14,6 +14,14 @@ INITIALIZESCRIPTHOST fpInitializeScriptHost = NULL;
 // thiscall hooking hack
 int __fastcall DetourInitializeScriptHost(void* me, void* _) {
 	printf("Initializing ScriptHost");
+
+	// We load plugins just before the script-host is initialized so that
+	// plugins can initialize their own state before the script-host gets
+	// a chance to call their internal Mono calls.
+	// And we load them here, instead of in `Core::Initialize`, so that we're
+	// not calling `LoadLibrary` within the context of our DLLMain.
+	// (See: https://learn.microsoft.com/windows/win32/dlls/dynamic-link-library-best-practices)
+	Core::GetInstance()->LoadPlugins();
 	int result = fpInitializeScriptHost(me);
 	MonoHooks::InitializeScriptHost();
 	ScriptHost::GetInstance()->CreateMonoClass("MonoPatcherLib", "DLLEntryPoint");
@@ -29,6 +37,22 @@ Core* Core::GetInstance() {
 bool Core::Create() {
 	_instance = new Core();
 	return _instance->Initialize();
+}
+
+void Core::LoadPlugins() {
+	printf("\nLoading plugins.\n");
+	std::filesystem::path path(L"MonoPatcher/plugins/");
+	std::error_code error;
+	for (auto& p : std::filesystem::recursive_directory_iterator(path, error)) {
+		auto extension = p.path().extension();
+		auto& e = extension.native();
+		if (e.length() != 4) continue;
+		if (((e[1] != 'd') & (e[1] != 'D')) | ((e[2] != 'l') & (e[2] != 'L')) | ((e[3] != 'l') & (e[3] != 'L'))) continue;
+		HMODULE lib = LoadLibraryW(p.path().c_str());
+		if (!lib) continue;
+		loadedPlugins.emplace_back(lib);
+		printf("Loaded Plugin: %ls\n", p.path().c_str());
+	}
 }
 
 bool Core::Initialize() {

--- a/MonoPatcher.CPP/src/MonoHooks.cpp
+++ b/MonoPatcher.CPP/src/MonoHooks.cpp
@@ -58,25 +58,23 @@ void MonoHooks::InitializeScriptHost() {
 	mono_add_internal_call("MonoPatcherLib.Internal.Hooking::ReplaceMethodIL", replace_il_for_mono_method);
 	mono_add_internal_call("MonoPatcherLib.Internal.Hooking::ForceJIT", force_jit);
 
-        // Add plugin-defined internal calls.
-        printf("\nAdding custom ICalls.\n");
-        std::string path("./MonoPatcher/plugins/");
-        if (!std::filesystem::exists(path)) {
-          return;
-        }
-        std::string ext(".dll");
-        for (auto& p : std::filesystem::recursive_directory_iterator(path)) {
-          HMODULE lib = LoadLibraryA(p.path().string().c_str());
-          if (!lib) continue;
-          FARPROC libEntry = GetProcAddress(lib, "ICallSetup");
-          if (!libEntry) continue;
-          typedef void (*ICallSetupPtr)(void (*mono_add_internal_call)(const
-                                                                       char *name, const void *method));
-          ICallSetupPtr ICallSetup = (ICallSetupPtr)libEntry;
-          ICallSetup(mono_add_internal_call);
-          printf("Loaded Plugin: %s\n", p.path().string().c_str());
-
-        }
+	// Add plugin-defined internal calls.
+	printf("\nAdding custom ICalls.\n");
+	std::string path("./MonoPatcher/plugins/");
+	if (!std::filesystem::exists(path)) {
+	  return;
+	}
+	std::string ext(".dll");
+	for (auto& p : std::filesystem::recursive_directory_iterator(path)) {
+		HMODULE lib = LoadLibraryA(p.path().string().c_str());
+		if (!lib) continue;
+		FARPROC libEntry = GetProcAddress(lib, "ICallSetup");
+		if (!libEntry) continue;
+		typedef void (*ICallSetupPtr)(void (*mono_add_internal_call)(const char *name, const void *method));
+		ICallSetupPtr ICallSetup = (ICallSetupPtr)libEntry;
+		ICallSetup(mono_add_internal_call);
+		printf("Loaded Plugin: %s\n", p.path().string().c_str());
+	}
 }
 
 bool MonoHooks::Initialize() {

--- a/MonoPatcher.CPP/src/MonoHooks.cpp
+++ b/MonoPatcher.CPP/src/MonoHooks.cpp
@@ -61,11 +61,9 @@ void MonoHooks::InitializeScriptHost() {
 	// Add plugin-defined internal calls.
 	printf("\nAdding custom ICalls.\n");
 	std::string path("./MonoPatcher/plugins/");
-	if (!std::filesystem::exists(path)) {
-	  return;
-	}
 	std::string ext(".dll");
-	for (auto& p : std::filesystem::recursive_directory_iterator(path)) {
+	std::error_code error;
+	for (auto& p : std::filesystem::recursive_directory_iterator(path, error)) {
 		HMODULE lib = LoadLibraryA(p.path().string().c_str());
 		if (!lib) continue;
 		FARPROC libEntry = GetProcAddress(lib, "ICallSetup");

--- a/MonoPatcher.CPP/src/MonoHooks.cpp
+++ b/MonoPatcher.CPP/src/MonoHooks.cpp
@@ -60,18 +60,18 @@ void MonoHooks::InitializeScriptHost() {
 
 	// Add plugin-defined internal calls.
 	printf("\nAdding custom ICalls.\n");
-	std::string path("./MonoPatcher/plugins/");
+	std::filesystem::path path(L"MonoPatcher/plugins/");
 	std::string ext(".dll");
 	std::error_code error;
 	for (auto& p : std::filesystem::recursive_directory_iterator(path, error)) {
-		HMODULE lib = LoadLibraryA(p.path().string().c_str());
+		HMODULE lib = LoadLibraryW(p.path().c_str());
 		if (!lib) continue;
 		FARPROC libEntry = GetProcAddress(lib, "ICallSetup");
 		if (!libEntry) continue;
 		typedef void (*ICallSetupPtr)(void (*mono_add_internal_call)(const char *name, const void *method));
 		ICallSetupPtr ICallSetup = (ICallSetupPtr)libEntry;
 		ICallSetup(mono_add_internal_call);
-		printf("Loaded Plugin: %s\n", p.path().string().c_str());
+		printf("Loaded Plugin: %ls\n", p.path().c_str());
 	}
 }
 

--- a/MonoPatcher.CPP/src/MonoHooks.cpp
+++ b/MonoPatcher.CPP/src/MonoHooks.cpp
@@ -61,9 +61,12 @@ void MonoHooks::InitializeScriptHost() {
 	// Add plugin-defined internal calls.
 	printf("\nAdding custom ICalls.\n");
 	std::filesystem::path path(L"MonoPatcher/plugins/");
-	std::string ext(".dll");
 	std::error_code error;
 	for (auto& p : std::filesystem::recursive_directory_iterator(path, error)) {
+		auto extension = p.path().extension();
+		auto& e = extension.native();
+		if (e.length() != 4) continue;
+		if (((e[1] != 'd') & (e[1] != 'D')) | ((e[2] != 'l') & (e[2] != 'L')) | ((e[3] != 'l') & (e[3] != 'L'))) continue;
 		HMODULE lib = LoadLibraryW(p.path().c_str());
 		if (!lib) continue;
 		FARPROC libEntry = GetProcAddress(lib, "ICallSetup");


### PR DESCRIPTION
As it stands, PDB and config files and the like can't be alongside plugin DLLs without effecting an error dialog at start-up.

- Commit 1 fixes the indentation of the plugin-loading code, so that it matches the rest of the function.
- Commit 2 removes a call to `std::filesystem::exists` and instead just uses a non-throwing overload of `std::filesystem::recursive_directory_iterator`.
- Commit 3 keeps the paths as-is and uses `LoadLibraryW` instead of converting them to UTF-8 for `LoadLibraryA` (the A does not stand for UTF-8).
- Commit 4 skips files with a file-extension other than `.dll`. (All the case-insensitive handling functions in the standard library seem to rely on the C locale, and we only care about ASCII here so I just did it the straightforward way.)
