### PR TITLE
Add declarative syntax for IL weaving on plugin initialization

### DIFF
--- a/MonoPatcher/ILPatch.cs
+++ b/MonoPatcher/ILPatch.cs
@@ -39,7 +39,7 @@ namespace MonoPatcherLib
         /// <remarks>
         /// If <c>TargetFragment.Length</c> is not equal to <c>ReplacementFragment.Length</c>, this method will have no effect.
         /// </remarks>
-        public void Replace()
+        public void Apply()
         {
             // Cache properties in local variables, to avoid duplication if implementations are computed and not field-backed
             var targetMethod = TargetMethod;

--- a/MonoPatcher/ILPatch.cs
+++ b/MonoPatcher/ILPatch.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 namespace MonoPatcherLib
 {
     /// <summary>
-    /// This class can be implemented to replace parts of a method using IL weaving.
+    /// This class can be implemented to replace parts of a method body using IL weaving.
     /// </summary>
     /// <remarks>
     /// Having multiple IL replacements on the same method generally will not conflict, unless they both modify the same IL instructions.<br/>

--- a/MonoPatcher/ILPatch.cs
+++ b/MonoPatcher/ILPatch.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Reflection;
+
+namespace MonoPatcherLib
+{
+    /// <summary>
+    /// This class can be implemented to replace parts of a method using IL weaving.
+    /// </summary>
+    /// <remarks>
+    /// Having multiple IL replacements on the same method generally will not conflict, unless they both modify the same IL instructions.<br/>
+    /// Whole-method replacements (e.g. <seealso cref="ReplaceMethodAttribute"/>) will override any already-applied IL patches, but patches can still be applied after replacement, so long as the bytecode segment to replace still exists.
+    /// </remarks>
+    public abstract class ILPatch
+    {
+        /// <summary>
+        /// Gets a <see cref="MethodInfo"/> representing the method to be patched.
+        /// </summary>
+        protected abstract MethodInfo TargetMethod { get; }
+        /// <summary>
+        /// Gets an array representing a bytecode segment within <see cref="TargetMethod">TargetMethod</see> to be replaced.
+        /// </summary>
+        /// <remarks>
+        /// Make sure the target IL fragment is exactly the same length as its replacement.
+        /// This can be done by e.g. adding <c>nop</c>s, or using <c>dup</c> rather than <c>stloc</c> + <c>ldloc</c> to reuse stack values.
+        /// </remarks>
+        protected abstract byte[] TargetFragment { get; }
+        /// <summary>
+        /// Gets an array representing a bytecode segment that will replace <see cref="TargetFragment">TargetFragment</see> within <see cref="TargetMethod">TargetMethod</see>.
+        /// </summary>
+        /// <remarks>
+        /// Make sure the replacement IL fragment is exactly the same length as the original.
+        /// This can be done by e.g. adding <c>nop</c>s, or using <c>dup</c> rather than <c>stloc</c> + <c>ldloc</c> to reuse stack values.
+        /// </remarks>
+        protected abstract byte[] ReplacementFragment { get; }
+
+        /// <summary>
+        /// Replaces the first instance of <see cref="TargetFragment">TargetFragment</see> within the body of <see cref="TargetMethod">TargetMethod</see> with <see cref="ReplacementFragment">ReplacementFragment</see>.
+        /// </summary>
+        /// <remarks>
+        /// If <c>TargetFragment.Length</c> is not equal to <c>ReplacementFragment.Length</c>, this method will have no effect.
+        /// </remarks>
+        public void Replace()
+        {
+            // Cache properties in local variables, to avoid duplication if implementations are computed and not field-backed
+            var targetMethod = TargetMethod;
+            var targetFragment = TargetFragment;
+            var replacementFragment = ReplacementFragment;
+
+            if (targetFragment.Length != replacementFragment.Length) return;
+
+            var methodIl = MonoPatcher.GetIL(targetMethod);
+
+            var replaceIndex = Utility.FindInByteArray(methodIl, targetFragment);
+
+            if (replaceIndex == -1) return;
+
+            Array.Copy(replacementFragment, 0, methodIl, replaceIndex, replacementFragment.Length);
+            MonoPatcher.ReplaceIL(targetMethod, methodIl);
+        }
+    }
+}

--- a/MonoPatcher/MonoPatcher.cs
+++ b/MonoPatcher/MonoPatcher.cs
@@ -109,25 +109,22 @@ namespace MonoPatcherLib
         /// </summary>
         public static void ReplaceMethod(MethodInfo originalMethod, MethodInfo replacementMethod)
         {
-            unsafe
+            var originalMethodHandle = originalMethod.MethodHandle.Value;
+            var replacementMethodHandle = replacementMethod.MethodHandle.Value;
+            var replacementByteArray = new byte[40];
+            Marshal.Copy(replacementMethodHandle, replacementByteArray, 0, 40);
+
+            // Don't replace name for metadata/reflection/etc reasons.
+            Marshal.Copy(replacementByteArray, 0, originalMethodHandle, 24);
+            Marshal.Copy(replacementByteArray, 28, new IntPtr(originalMethodHandle.ToInt32() + 28), 12);
+
+            Log($"Replaced {originalMethod.Name} ({originalMethodHandle.ToInt32().ToString("X")}) with {replacementMethod.Name} ({replacementMethodHandle.ToInt32().ToString("X")})");
+            ReplacementCount++;
+
+            if (Hooking.WeavedMethods.TryGetValue(originalMethodHandle, out var weavedMethod))
             {
-                var originalMethodHandle = originalMethod.MethodHandle.Value;
-                var replacementMethodHandle = replacementMethod.MethodHandle.Value;
-                var replacementByteArray = new byte[40];
-                Marshal.Copy(replacementMethodHandle, replacementByteArray, 0, 40);
-
-                // Don't replace name for metadata/reflection/etc reasons.
-                Marshal.Copy(replacementByteArray, 0, originalMethodHandle, 24);
-                Marshal.Copy(replacementByteArray, 28, new IntPtr(originalMethodHandle.ToInt32() + 28), 12);
-
-                Log($"Replaced {originalMethod.Name} ({originalMethodHandle.ToInt32().ToString("X")}) with {replacementMethod.Name} ({replacementMethodHandle.ToInt32().ToString("X")})");
-                ReplacementCount++;
-
-                if (Hooking.WeavedMethods.TryGetValue(originalMethodHandle, out var weavedMethod))
-                {
-                    weavedMethod.Dispose();
-                    Hooking.WeavedMethods.Remove(originalMethodHandle);
-                }
+                weavedMethod.Dispose();
+                Hooking.WeavedMethods.Remove(originalMethodHandle);
             }
         }
 

--- a/MonoPatcher/MonoPatcher.cs
+++ b/MonoPatcher/MonoPatcher.cs
@@ -99,7 +99,7 @@ namespace MonoPatcherLib
                 }
                 if (canIlWeave && typeof(ILPatch).IsAssignableFrom(type))
                 {
-                    (Activator.CreateInstance(type) as ILPatch).Replace();
+                    (Activator.CreateInstance(type) as ILPatch).Apply();
                 }
             }
             AlreadyPatchedAssemblies.Add(assembly);

--- a/MonoPatcher/MonoPatcher.cs
+++ b/MonoPatcher/MonoPatcher.cs
@@ -97,7 +97,7 @@ namespace MonoPatcherLib
                         (propPatch as ReplacePropertyAttribute).Apply(prop);
                     }
                 }
-                if (canIlWeave && typeof(ILPatch).IsAssignableFrom(type))
+                if (canIlWeave && typeof(ILPatch).IsAssignableFrom(type) && !type.IsAbstract)
                 {
                     (Activator.CreateInstance(type) as ILPatch).Apply();
                 }

--- a/MonoPatcher/MonoPatcher.cs
+++ b/MonoPatcher/MonoPatcher.cs
@@ -96,6 +96,10 @@ namespace MonoPatcherLib
                         (propPatch as ReplacePropertyAttribute).Apply(prop);
                     }
                 }
+                if (typeof(ILPatch).IsAssignableFrom(type))
+                {
+                    (Activator.CreateInstance(type) as ILPatch).Replace();
+                }
             }
             AlreadyPatchedAssemblies.Add(assembly);
         }

--- a/MonoPatcher/MonoPatcher.cs
+++ b/MonoPatcher/MonoPatcher.cs
@@ -70,6 +70,7 @@ namespace MonoPatcherLib
         public static void PatchAll(Assembly assembly)
         {
             if (AlreadyPatchedAssemblies.Contains(assembly)) return;
+            var canIlWeave = InitializationType == InitializationTypes.CPP;
             var types = assembly.GetTypes();
             foreach(var type in types)
             {
@@ -96,7 +97,7 @@ namespace MonoPatcherLib
                         (propPatch as ReplacePropertyAttribute).Apply(prop);
                     }
                 }
-                if (typeof(ILPatch).IsAssignableFrom(type))
+                if (canIlWeave && typeof(ILPatch).IsAssignableFrom(type))
                 {
                     (Activator.CreateInstance(type) as ILPatch).Replace();
                 }

--- a/MonoPatcher/MonoPatcher.csproj
+++ b/MonoPatcher/MonoPatcher.csproj
@@ -51,6 +51,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ForceRecompilation.cs" />
+    <Compile Include="ILPatch.cs" />
     <Compile Include="Internal\Hooking.cs" />
     <Compile Include="ReplaceMethodAttribute.cs" />
     <Compile Include="ReplacePropertyAttribute.cs" />

--- a/Samples/SamplePatches/Main.cs
+++ b/Samples/SamplePatches/Main.cs
@@ -1,13 +1,9 @@
 ﻿using MonoPatcherLib;
 using Sims3.Gameplay.CAS;
 using Sims3.Gameplay.Utilities;
-using Sims3.SimIFace;
-using Sims3.UI;
 using Sims3.UI.OnlineDating;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace SamplePatches
 {
@@ -49,36 +45,39 @@ namespace SamplePatches
         }
 
         // Same as the above patch, but using IL weaving. For more advanced users - harder and limited, but more compatible as multiple IL patches can be stacked together.
-        private void ILPatch_GetDefaultBodyType()
+        public class GetDefaultBodyTypeILPatch : ILPatch
         {
-            // Can only do IL weaving if the ASI is loaded.
-            if (MonoPatcher.InitializationType != MonoPatcher.InitializationTypes.CPP) return;
+            protected override MethodInfo TargetMethod
+            {
+                get
+                {
+                    return typeof(OnlineDatingProfile).GetMethod(nameof(OnlineDatingProfile.GetDefaultBodyType), BindingFlags.NonPublic | BindingFlags.Instance);
+                }
+            }
 
-            var GetDefaultBodyTypeMethod = typeof(OnlineDatingProfile).GetMethod(nameof(OnlineDatingProfile.GetDefaultBodyType), BindingFlags.NonPublic | BindingFlags.Instance);
+            protected override byte[] TargetFragment
+            {
+                get
+                {
+                    return new byte[]
+                    {
+                        // ldc.r4
+                        0x22,
+                        // 0f
+                        0x00, 0x00, 0x00, 0x00
+                    };
+                }
+            }
 
-            // Get the bytecode from the method
-            var il = MonoPatcher.GetIL(GetDefaultBodyTypeMethod);
-
-            // Look for the instruction that loads a 0.0 float
-
-            var search = new byte[5];
-            // ldc.r4
-            search[0] = 0x22;
-            // float 0
-            search[1] = 0x0;
-            search[1] = 0x0;
-            search[1] = 0x0;
-            search[1] = 0x0;
-
-            var weightLocation = Utility.FindInByteArray(il, search);
-
-            if (weightLocation == -1) return;
-
-            // Replace the 0.0 float with 0.5
-            Array.Copy(BitConverter.GetBytes(0.5f), 0, il, weightLocation + 1, 4);
-
-            // Patch the method
-            MonoPatcher.ReplaceIL(GetDefaultBodyTypeMethod, il);
+            protected override byte[] ReplacementFragment
+            {
+                get
+                {
+                    var il = TargetFragment;
+                    BitConverter.GetBytes(0.5f).CopyTo(il, 1);
+                    return il;
+                }
+            }
         }
     }
 }

--- a/Samples/SamplePatches/SimPatch.cs
+++ b/Samples/SamplePatches/SimPatch.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using MonoPatcherLib;
+﻿using MonoPatcherLib;
 using Sims3.Gameplay.Actors;
-using Sims3.Gameplay.Controllers;
 
 namespace SamplePatches
 {


### PR DESCRIPTION
This creates an abstract `ILPatch` class that can be implemented in client plugins to simplify the process of IL weaving a bit. The motivation is to provide a more declarative mechanism similar to the existing patch attributes, where users can opt-in to automatically perform weaving as part of plugin initialization by providing only the target method fragment and desired replacement.

Unlike the `MethodPatchAttribute` and `PropertyPatchAttribute`, where the target `MethodInfo` is reflected for you given a type and name/args, here it must be supplied by the client implementation. I figure if you're skilled enough to work with IL, you can probably handle using reflection yourself :)

I'm not 100% sure if the replacement bytecode needs to be exactly the same length as the target, but in my testing the game has crashed on invocation if it isn't, so I've added it as a requirement for the patch to run.

## Example Usage
I use C# 6 [expression-bodied properties](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties#expression-body-definitions) and C# 12 [collection expression](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions) syntax here to make things easier to read.

### Implementing the example from [the wiki](https://github.com/LazyDuchess/MonoPatcher/wiki/IL-Weaving)
```cs
[Plugin]
public class MyPlugin 
{
    public class GetDefaultBodyTypePatch : ILPatch
    {
        protected override MethodInfo TargetMethod 
            => typeof(OnlineDatingProfile).GetMethod(nameof(OnlineDatingProfile.GetDefaultBodyType), BindingFlags.NonPublic | BindingFlags.Instance);
    
        protected override byte[] TargetFragment => 
        [
            // ldc.r4
            0x22,
            // 0f
            0x00,0x00,0x00,0x00
        ];
    
        protected override byte[] ReplacementFragment =>
        [
            // ldc.r4
            0x22,
            .. BitConverter.GetBytes(0.5f)
        ];
    }
}
```

### More complex patch w/ EA 1.69 metadata tokens
```cs
[Plugin]
public class MyPlugin 
{
    /** 
     * OnAskForAdvice handles the notification and moodlet you get from asking a butler for life advice.
     * The goal of this patch is to pass the actor Sim as an object param to LocalizeString(),
     * So we can replace the butler's use of sir/madam with the Sim's name.
     * Since only {MB}/{FB} is used in the vanilla string (at least in English),
     * We will omit the target.IsFemale call to make space for the extra instructions to build the params array
     */
    public class AskForAdvicePatch : ILPatch
    {
        protected override MethodInfo TargetMethod =>
            typeof(SocialCallback).GetMethod(nameof(SocialCallback.OnAskForAdvice));
    
        protected override byte[] TargetFragment =>
        [
            // ldc.i4.2
            0x18,
            // newarr
            0x8d,
            /** 
             * WARNING: These tokens will only work with 1.69! 
             * Other versions will crash due to differences in compiled assembly metadata
             */
            // typeref rid 822 (System.Boolean)
            0x36, 0x03, 0x00, 0x01,
            // stloc.1
            0x0b,
            // ldloc.1
            0x07,
            // ldc.i4.0
            0x16,
            // ldarg.1
            0x03,
            // callvirt
            0x6f,
            // methoddef rid 2995 (Sim.IsFemale)
            0xb3, 0x0b, 0x00, 0x06,
            // stelem.i1
            0x9c,

            // ldloc.1
            0x07,
            // ldc.i4.1
            0x17,
            // ldarg.0
            0x02,
            // callvirt
            0x6f,
            // methoddef rid 2995 (Sim.IsFemale)
            0xb3, 0x0b, 0x00, 0x06,
            // stelem.i1
            0x9c,

            // ldloc.1
            0x07,
            // ldstr
            0x72,
            // "Gameplay/Actors/Sim/AskForAdvice:Response"
            0x98, 0xee, 0x08, 0x70,

            // ldc.i4.0
            0x16,
            // newarr
            0x8d,
            // typeref rid 1 (System.Object)
            0x01, 0x00, 0x00, 0x01
        ];
    
        protected override byte[] ReplacementFragment =>
        [
            // Nop padding to match fragment length
            0x00,0x00,0x00,0x00,0x00,0x00,0x00,

            // ldc.i4.1
            0x17,
            // newarr
            0x8d,
            // typeref rid 822 (System.Boolean)
            0x36, 0x03, 0x00, 0x01,
            // dup
            0x25,
            // ldc.i4.0
            0x16,
            // ldarg.0
            0x02,
            // callvirt
            0x6f,
            // methoddef rid 2995 (Sim.IsFemale)
            0xb3, 0x0b, 0x00, 0x06,
            // stelem.i1
            0x9c,

            // ldstr
            0x72,
            // "Gameplay/Actors/Sim/AskForAdvice:Response"
            0x98, 0xee, 0x08, 0x70,

            /* The important part */
            // ldc.i4.1
            0x17,
            // newarr
            0x8d,
            // typeref rid 1 (System.Object)
            0x01, 0x00, 0x00, 0x01,

            // dup
            0x25,
            // ldc.i4.0
            0x16,
            // ldarg.0
            0x02,
            // stelem.ref
            0xa2,
        ];
    }
}
```

Before:
```cs
public static void OnAskForAdvice(Sim actor, Sim target, string interaction, ActiveTopic topic, InteractionInstance i)
{
    string message = Localization.LocalizeString(new bool[]
    {
        target.IsFemale,
        actor.IsFemale
    }, "Gameplay/Actors/Sim/AskForAdvice:Response", new object[0]);
    actor.ShowTNSIfSelectable(message, StyledNotification.NotificationStyle.kSimTalking, target.ObjectId, actor.ObjectId);
    if (RandomUtil.RandomChance(Butler.ChanceGetGoodAdviceMoodlet))
    {
        actor.BuffManager.AddElement(BuffNames.GoodAdvice, Origin.FromSocialization);
    }
}

/**
 * Example string output:
 * 
 * "The best advice, {MB.Sir}{FB.Madam}, ..." => "The best advice, Madam, ..."
 * "The best advice, {1.SimFirstName}, ..."   => "The best advice, , ..."
 */
```

After:
```cs
public static void OnAskForAdvice(Sim actor, Sim target, string interaction, ActiveTopic topic, InteractionInstance i)
{
    string message = Localization.LocalizeString(new bool[]
    {
        actor.IsFemale
    }, "Gameplay/Actors/Sim/AskForAdvice:Response", new object[]
    {
        actor
    });
    actor.ShowTNSIfSelectable(message, StyledNotification.NotificationStyle.kSimTalking, target.ObjectId, actor.ObjectId);
    if (RandomUtil.RandomChance(Butler.ChanceGetGoodAdviceMoodlet))
    {
        actor.BuffManager.AddElement(BuffNames.GoodAdvice, Origin.FromSocialization);
    }
}

/**
 * Example string output:
 * 
 * "The best advice, {MA.Sir}{FA.Madam}, ..." => "The best advice, Madam, ..."
 * "The best advice, {0.SimFirstName}, ..."   => "The best advice, Alice, ..."
 */
```

## Possible Future Enhancements
Maybe add instruction constants, enforce instruction arg requirements, and/or provide a way to specify metadata tokens per game version, to make bytecode wrangling a little easier